### PR TITLE
Get confirmed events for live events widget

### DIFF
--- a/calendar-events.js
+++ b/calendar-events.js
@@ -38,7 +38,9 @@ function todayDate(){
 }
 
 function getSortedEvents(eventsData){
-	return eventsData.items.map(function(event){
+	return eventsData.items.filter(function(event) {
+		return event.status !== 'cancelled';
+	}).map(function(event){
 		var clone = Object.assign({}, event);
 		var dateStr = event.start.dateTime || event.start.date;
 		var date = new Date(dateStr);


### PR DESCRIPTION
Filter the displayed live events to show only the confirmed ones, currently the events are not displayed because of error thrown by cancelled events, cancelled events don't have date properties.

<img width="1186" alt="Screen Shot 2020-08-14 at 10 50 48 PM" src="https://user-images.githubusercontent.com/109013/90295424-e2c59080-de80-11ea-9816-66289eabd943.png">
